### PR TITLE
Pulse assember and execute

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -24,7 +24,7 @@ from qiskit.circuit import QuantumRegister
 from qiskit.circuit import QuantumCircuit
 # pylint: disable=redefined-builtin
 from qiskit.tools.compiler import compile  # TODO remove after 0.8
-from qiskit.execute import (execute_circuits, execute)
+from qiskit.execute import (execute_circuits, execute_schedules, execute)
 
 # The qiskit.extensions.x imports needs to be placed here due to the
 # mechanism for adding gates dynamically.

--- a/qiskit/compiler/__init__.py
+++ b/qiskit/compiler/__init__.py
@@ -11,5 +11,5 @@
 
 from .run_config import RunConfig
 from .transpile_config import TranspileConfig
-from .assembler import assemble_circuits
+from .assembler import assemble_circuits, assemble_schedules
 from .transpiler import transpile

--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -12,10 +12,14 @@ import numpy
 import sympy
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
+from qiskit.pulse import Schedule, SamplePulse, FrameChange, PersistentValue, Acquire, Snapshot
 from qiskit.compiler.run_config import RunConfig
-from qiskit.qobj import (QasmQobj, QobjExperimentHeader, QobjHeader,
+from qiskit.qobj import (QasmQobj, PulseQobj, QobjExperimentHeader, QobjHeader,
                          QasmQobjInstruction, QasmQobjExperimentConfig, QasmQobjExperiment,
-                         QasmQobjConfig, QobjConditional)
+                         QasmQobjConfig, QobjConditional,
+                         PulseQobjInstruction, PulseQobjExperimentConfig, PulseQobjExperiment,
+                         PulseQobjConfig, QobjPulseLibrary, QobjMeasurementOption)
+from qiskit.exceptions import QiskitError
 
 
 def assemble_circuits(circuits, run_config=None, qobj_header=None, qobj_id=None):
@@ -120,3 +124,105 @@ def assemble_circuits(circuits, run_config=None, qobj_header=None, qobj_id=None)
 
     return QasmQobj(qobj_id=qobj_id or str(uuid.uuid4()), config=userconfig,
                     experiments=experiments, header=qobj_header)
+
+
+def assemble_schedules(schedules, dict_config, dict_header):
+    """Assembles a list of circuits into a qobj which can be run on the backend.
+
+    Args:
+        schedules (list[PulseSchedule] or PulseSchedule): schedules to assemble
+        dict_config (dict): configuration of experiments
+        dict_header (dict): header to pass to the results
+
+    Returns:
+        PulseQobj: the Qobj to be run on the backends
+
+    Raises:
+        QiskitError: when invalid command is provided
+    """
+    if isinstance(schedules, Schedule):
+        schedules = [schedules]
+
+    experiments = []
+
+    for schedule in schedules:
+
+        # add new pulses in the schedule
+        cmds = schedule.get_sample_pulses()
+        for cmd in cmds:
+            if cmd.name not in [libcmd['name'] for libcmd in dict_config['pulse_library']]:
+                dict_config['pulse_library'].append({'name': cmd.name, 'samples': cmd.samples})
+
+        lo_freqs = {
+            'qubit_lo_freq': schedule.channels.drive.lo_frequencies(),
+            'meas_lo_freq': schedule.channels.measure.lo_frequencies()
+        }
+
+        # generate experimental configuration
+        experimentconfig = PulseQobjExperimentConfig(**lo_freqs)
+
+        # generate experimental header
+        experimentheader = QobjExperimentHeader(name=schedule.name)
+
+        # TODO: support conditional gate
+        commands = []
+        for pulse in schedule.flat_pulse_sequence():
+            current_command = PulseQobjInstruction(name=pulse.command.name,
+                                                   t0=pulse.start_time())
+            if isinstance(pulse.command, SamplePulse):
+                current_command.ch = pulse.channel.name
+            elif isinstance(pulse.command, FrameChange):
+                current_command.ch = pulse.channel.name
+                current_command.phase = pulse.command.phase
+            elif isinstance(pulse.command, PersistentValue):
+                current_command.ch = pulse.channel.name
+                current_command.val = pulse.command.value
+            elif isinstance(pulse.command, Acquire):
+                # TODO: now all qubit are measured at once regardless of channel definition
+                n_qubit = dict_config['memory_slots']
+                current_command.duration = pulse.command.duration
+                current_command.qubits = list(range(n_qubit))
+                current_command.memory_slot = list(range(n_qubit))
+                # apply discriminator
+                if dict_config['meas_level'] == 2:
+                    current_command.register_slot = list(range(n_qubit))
+                    _discriminator = pulse.command.discriminator
+                    if _discriminator:
+                        qobj_discriminator = QobjMeasurementOption(name=_discriminator.name,
+                                                                   params=_discriminator.params)
+                        current_command.discriminators = [qobj_discriminator]
+                    else:
+                        current_command.discriminators = []
+                # apply kernel
+                if dict_config['meas_level'] >= 1:
+                    _kernel = pulse.command.kernel
+                    if _kernel:
+                        qobj_kernel = QobjMeasurementOption(name=_kernel.name,
+                                                            params=_kernel.params)
+                        current_command.kernels = [qobj_kernel]
+                    else:
+                        current_command.kernels = []
+            elif isinstance(pulse.command, Snapshot):
+                current_command.label = pulse.command.label
+                current_command.type = pulse.command.type
+            else:
+                raise QiskitError('Invalid command is given, %s' % pulse.command.name)
+
+            commands.append(current_command)
+
+        experiments.append(PulseQobjExperiment(instructions=commands,
+                                               header=experimentheader,
+                                               config=experimentconfig))
+
+    # generate qobj pulse library
+    qobj_pulselib = []
+    for pulse in dict_config['pulse_library']:
+        qobj_pulselib.append(QobjPulseLibrary(name=pulse['name'],
+                                              samples=pulse['samples']))
+    dict_config['pulse_library'] = qobj_pulselib
+
+    qobj_config = PulseQobjConfig(**dict_config)
+    qobj_header = QobjHeader(**dict_header)
+
+    return PulseQobj(qobj_id=str(uuid.uuid4()), config=qobj_config,
+                     experiments=experiments, header=qobj_header)

--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -171,8 +171,7 @@ def execute_schedules(schedules, backend, **kwargs):
         'meas_lo_freq': backend_config.defaults['meas_freq_est'],
         'rep_time': backend_config.rep_times[-1]
     }
-    for key, value in kwargs.items():
-        config[key] = value
+    config.update(kwargs)
 
     # filling in the header with the backend name the qobj was run on
     header = {

--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -19,7 +19,7 @@ running quickly we have provider this wrapper module.
 import logging
 import warnings
 
-from qiskit.compiler import assemble_circuits, transpile
+from qiskit.compiler import assemble_circuits, assemble_schedules, transpile
 from qiskit.compiler import RunConfig, TranspileConfig
 from qiskit.qobj import QobjHeader
 
@@ -131,3 +131,55 @@ def execute_circuits(circuits, backend, qobj_header=None,
 
     # executing the circuits on the backend and returning the job
     return backend.run(qobj, **kwargs)
+
+
+def execute_schedules(schedules, backend, **kwargs):
+    """Executes a list of circuits.
+
+    Args:
+        schedules (PulseSchedule or list[PulseSchedule]): schedules to execute
+        backend (BaseBackend): a backend to execute the schedules on
+
+    Keyword Args:
+        shots (int): number of repetitions of each circuit, for sampling
+        max_credits (int): maximum credits to use
+        seed (int): random seed for simulators
+        meas_level (int): set the appropriate level of the measurement output.
+        memory_slots (int): number of classical memory slots used in this job.
+        memory_slot_size (int): size of each memory slot if the output is Level 0.
+        meas_return (str): indicates the level of measurement information to return.
+            "single" returns information from every shot of the experiment.
+            "avg" returns the average measurement output (averaged over the number of shots).
+            If the meas level is 2 then this is fixed to single.
+        rep_time (int): repetition time of the experiment in μs.
+            The delay between experiments will be rep_time.
+            Must be from the list provided by the device.
+
+    Returns:
+        BaseJob: returns job instance derived from BaseJob
+    """
+    backend_config = backend.configuration()
+
+    # filling in the config with backend defaults and user defined
+    config = {
+        'meas_level': 1,
+        'memory_slots': backend_config.n_qubits,
+        'memory_slot_size': 100,
+        'meas_return': 'avg',
+        'pulse_library': backend_config.defaults.get('pulse_library', []),
+        'qubit_lo_freq': backend_config.defaults['qubit_freq_est'],
+        'meas_lo_freq': backend_config.defaults['meas_freq_est'],
+        'rep_time': backend_config.rep_times[-1]
+    }
+    for key, value in kwargs.items():
+        config[key] = value
+
+    # filling in the header with the backend name the qobj was run on
+    header = {
+        'backend_name': backend.name(),
+        'backend_version': backend_config.backend_version
+    }
+
+    qobj = assemble_schedules(schedules=schedules, dict_header=header, dict_config=config)
+
+    return backend.run(qobj)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This adds `assemble_schedule` and `execute_schedule` to compile `Schedule` to `PulseQobj` and run on the backend. The last piece to complete this branch. After this is merged, `pulse_channel` and `pulse_user_test` will be equivalent.

### Details and comments


