### PR TITLE
Hide memory slot from command interface

### DIFF
--- a/qiskit/pulse/channels/device_specification.py
+++ b/qiskit/pulse/channels/device_specification.py
@@ -30,7 +30,6 @@ class DeviceSpecification:
         """
         self._qubits = qubits
         self._reg_slots = registers
-        self._mem_slots = [MemorySlot(i) for i in range(len(qubits))]
 
     @classmethod
     def create_from(cls, backend):
@@ -62,7 +61,6 @@ class DeviceSpecification:
         # generate channels with assuming their numberings are aligned with qubits
         drives = [DriveChannel(i, qubit_lo_freqs[i]) for i in range(n_qubits)]   # TODO: lo_ranges
         measures = [MeasureChannel(i, meas_lo_freqs[i]) for i in range(n_qubits)]  # TODO: lo_ranges
-        acquires = [AcquireChannel(i) for i in range(n_qubits)]
         controls = [ControlChannel(i) for i in range(n_uchannels)]
 
         qubits = []
@@ -70,8 +68,7 @@ class DeviceSpecification:
             qubit = Qubit(i,
                           drive_channels=[drives[i]],
                           control_channels=None if n_uchannels == 0 else controls[i],
-                          measure_channels=[measures[i]],
-                          acquire_channels=[acquires[i]])
+                          measure_channels=[measures[i]])
             qubits.append(qubit)
 
         registers = [RegisterSlot(i) for i in range(n_registers)]
@@ -102,8 +99,3 @@ class DeviceSpecification:
     def c(self) -> List[RegisterSlot]:
         """Return register slots in this device."""
         return self._reg_slots
-
-    @property
-    def mem(self) -> List[MemorySlot]:
-        """Return memory slots in this device."""
-        return self._mem_slots

--- a/qiskit/pulse/channels/qubit.py
+++ b/qiskit/pulse/channels/qubit.py
@@ -52,6 +52,10 @@ class Qubit:
         return False
 
     @property
+    def index(self) -> int:
+        return self._index
+
+    @property
     def drive(self) -> DriveChannel:
         """Return the primary drive channel of this qubit."""
         if self._drives:

--- a/qiskit/pulse/channels/qubit.py
+++ b/qiskit/pulse/channels/qubit.py
@@ -12,7 +12,7 @@ from typing import List
 
 from qiskit.pulse.exceptions import PulseError
 from .output_channel import DriveChannel, ControlChannel, MeasureChannel
-from .pulse_channel import AcquireChannel
+from .pulse_channel import AcquireChannel, MemorySlot
 
 
 class Qubit:
@@ -22,12 +22,14 @@ class Qubit:
                  drive_channels: List[DriveChannel] = None,
                  control_channels: List[ControlChannel] = None,
                  measure_channels: List[MeasureChannel] = None,
-                 acquire_channels: List[AcquireChannel] = None):
+                 acquire_channel: AcquireChannel = None,
+                 memory_slot: MemorySlot = None):
         self._index = index
         self._drives = drive_channels
         self._controls = control_channels
         self._measures = measure_channels
-        self._acquires = acquire_channels
+        self._acquire = acquire_channel or AcquireChannel(index)
+        self._mem_slot = memory_slot or MemorySlot(index)
 
     def __eq__(self, other):
         """Two physical qubits are the same if they have the same index and channels.
@@ -44,7 +46,8 @@ class Qubit:
                 self._drives == other._drives and \
                 self._controls == other._controls and \
                 self._measures == other._measures and \
-                self._acquires == other._acquires:
+                self._acquire == other._acquire and \
+                self._mem_slot == other._mem_slot:
             return True
         return False
 
@@ -74,8 +77,16 @@ class Qubit:
 
     @property
     def acquire(self) -> AcquireChannel:
-        """Return the primary acquire channel of this qubit."""
-        if self._acquires:
-            return self._acquires[0]
+        """Return the acquire channel of this qubit."""
+        if self._acquire:
+            return self._acquire
         else:
-            raise PulseError("No acquire channels in q[%d]" % self._index)
+            raise PulseError("No memory slot in q[%d]" % self._index)
+
+    @property
+    def mem_slot(self) -> MemorySlot:
+        """Return the memory slot of this qubit."""
+        if self._mem_slot:
+            return self._mem_slot
+        else:
+            raise PulseError("No memory slot in q[%d]" % self._index)

--- a/qiskit/pulse/commands/acquire.py
+++ b/qiskit/pulse/commands/acquire.py
@@ -97,8 +97,8 @@ class AcquireInstruction(Instruction):
         else:
             reg_slots = []
         self._command = command
-        self._acquire_channels = [q.acquire for q in qubits]
         self._qubits = qubits
+        self._mem_slots = [q.mem_slot for q in qubits]
         self._reg_slots = reg_slots
         # TODO: more precise time-slots
         slots = [Timeslot(Interval(0, command.duration), q.acquire) for q in qubits]
@@ -119,19 +119,19 @@ class AcquireInstruction(Instruction):
         return self._command
 
     @property
-    def acquire_channels(self):
-        """Acquire channels to be applied. """
-        return self._acquire_channels
-
-    @property
     def qubits(self):
         """Qubits to be acquired. """
         return self._qubits
 
     @property
+    def mem_slots(self):
+        """MemorySlots in which acquired results are stored. """
+        return self._mem_slots
+
+    @property
     def reg_slots(self):
-        """RegisterSlots in which acquired bit is stored. """
+        """RegisterSlots in which acquired bits are stored. """
         return self._reg_slots
 
     def __repr__(self):
-        return '%s >> #AcquireChannel=%d' % (self._command, len(self._acquire_channels))
+        return '%s >> q%s' % (self._command, str([q.index for q in self._qubits]))

--- a/test/python/pulse/test_channels.py
+++ b/test/python/pulse/test_channels.py
@@ -109,13 +109,13 @@ class TestQubit(QiskitTestCase):
         qubit = Qubit(1,
                       drive_channels=[DriveChannel(2, 1.2)],
                       control_channels=[ControlChannel(3)],
-                      measure_channels=[MeasureChannel(4)],
-                      acquire_channels=[AcquireChannel(5)])
+                      measure_channels=[MeasureChannel(4)])
 
         self.assertEqual(qubit.drive, DriveChannel(2, 1.2))
         self.assertEqual(qubit.control, ControlChannel(3))
         self.assertEqual(qubit.measure, MeasureChannel(4))
-        self.assertEqual(qubit.acquire, AcquireChannel(5))
+        self.assertEqual(qubit.acquire, AcquireChannel(1))
+        self.assertEqual(qubit.mem_slot, MemorySlot(1))
 
 
 class TestDeviceSpecification(QiskitTestCase):
@@ -125,15 +125,14 @@ class TestDeviceSpecification(QiskitTestCase):
         """Test default device specification.
         """
         qubits = [
-            Qubit(0, drive_channels=[DriveChannel(0, 1.2)], acquire_channels=[AcquireChannel(0)]),
-            Qubit(1, drive_channels=[DriveChannel(1, 3.4)], acquire_channels=[AcquireChannel(1)])
+            Qubit(0, drive_channels=[DriveChannel(0, 1.2)], acquire_channel=AcquireChannel(0)),
+            Qubit(1, drive_channels=[DriveChannel(1, 3.4)], acquire_channel=AcquireChannel(1))
         ]
         registers = [RegisterSlot(i) for i in range(2)]
         spec = DeviceSpecification(qubits, registers)
 
         self.assertEqual(spec.q[0].drive, DriveChannel(0, 1.2))
         self.assertEqual(spec.q[1].acquire, AcquireChannel(1))
-        self.assertEqual(spec.mem[0], MemorySlot(0))
         self.assertEqual(spec.c[1], RegisterSlot(1))
 
     def test_creation_from_backend_with_zero_u_channels(self):

--- a/test/python/pulse/test_schedule.py
+++ b/test/python/pulse/test_schedule.py
@@ -35,7 +35,7 @@ class TestSchedule(QiskitTestCase):
 
         qubits = [
             Qubit(0, drive_channels=[DriveChannel(0, 1.2)], control_channels=[ControlChannel(0)]),
-            Qubit(1, drive_channels=[DriveChannel(1, 3.4)], acquire_channels=[AcquireChannel(1)])
+            Qubit(1, drive_channels=[DriveChannel(1, 3.4)])
         ]
         registers = [RegisterSlot(i) for i in range(2)]
         device = DeviceSpecification(qubits, registers)
@@ -50,7 +50,7 @@ class TestSchedule(QiskitTestCase):
         sched.insert(60, gp0(device.q[0].control))
         sched.insert(80, Snapshot("label", "snap_type"))
         sched.insert(90, fc_pi_2(device.q[0].drive))
-        sched.insert(90, acquire(device.q[1], device.mem[1], device.c[1]))
+        sched.insert(90, acquire(device.q[1], device.c[1]))
         # print(sched)
 
         new_sched = Schedule()
@@ -64,19 +64,17 @@ class TestSchedule(QiskitTestCase):
     def test_absolute_begin_time_of_grandchild(self):
         """Test correct calculation of begin time of grandchild of a schedule.
         """
-        qubits = [
-            Qubit(0, acquire_channels=[AcquireChannel(0)]),
-        ]
+        qubits = [Qubit(0, acquire_channel=AcquireChannel(0))]
         registers = [RegisterSlot(i) for i in range(1)]
         device = DeviceSpecification(qubits, registers)
 
         acquire = Acquire(10)
         children = Schedule()
-        children.insert(20, acquire(device.q[0], device.mem[0]))   # grand child 1
-        children.append(acquire(device.q[0], device.mem[0]))       # grand child 2
+        children.insert(20, acquire(device.q[0]))   # grand child 1
+        children.append(acquire(device.q[0]))       # grand child 2
 
         sched = Schedule()
-        sched.append(acquire(device.q[0], device.mem[0]))   # child
+        sched.append(acquire(device.q[0]))   # child
         sched.append(children)
 
         begin_times = sorted([i.begin_time for i in sched.flat_instruction_sequence()])


### PR DESCRIPTION
Remove `mem_slots` arguments from `Acquire` command.
```
Acquire(10)(device.q[0]) # acquisition result is stored in memory slot 0
or
Acquire(10)(device.q[0], device.c[1]) # supported in the future
```
This change makes it clear that what users must care about is only the index of qubit.

### Details and comments
- Each `Qubit` have exactly one `AcquireChannel` and one `MemorySlot` which have the same index as the parent qubit.

Also this change more align with qobj.
```
[Current]
  current_command.qubits = [acqs.index for acqs in pulse_instr.acquire_channels]
[With this PR]
  current_command.qubits = [q.index for q in pulse_instr.qubits]
```
