### PR TITLE
Improve performance of parametrized pulse evaluation

### DIFF
--- a/qiskit/pulse/library/parametric_pulses.py
+++ b/qiskit/pulse/library/parametric_pulses.py
@@ -123,7 +123,6 @@ class ParametricPulse(Pulse):
             import sympy as sym
 
         params = {sym.Symbol(k): v for k, v in self.parameters.items()}
-        t = sym.Symbol("t")
         assigned_expr = self.definition.subs(params)
 
         # midpoint sampling
@@ -133,8 +132,9 @@ class ParametricPulse(Pulse):
             # lambdify fully supports the features required by parametric
             # pulses.
             import sympy
-            lambda_func = sympy.lambdify(t, sym.sympify(assigned_expr))
+            lambda_func = sympy.lambdify(sympy.Symbol("t"), sym.sympify(assigned_expr))
         else:
+            t = sym.Symbol("t")
             lambda_func = sym.lambdify(t, assigned_expr)
 
         waveform = lambda_func(times)

--- a/qiskit/pulse/library/parametric_pulses.py
+++ b/qiskit/pulse/library/parametric_pulses.py
@@ -129,8 +129,11 @@ class ParametricPulse(Pulse):
         # midpoint sampling
         times = np.arange(0, self.duration) + 1/2
         if optionals.HAS_SYMENGINE:
-            # this should be simplified to handle piecewise function
-            lambda_func = sym.lambdify(t, [assigned_expr.simplify()])
+            # Fall back to sympy for lambda function creation until symengine's
+            # lambdify fully supports the features required by parametric
+            # pulses.
+            import sympy
+            lambda_func = sympy.lambdify(t, sym.sympify(assigned_expr))
         else:
             lambda_func = sym.lambdify(t, assigned_expr)
 

--- a/qiskit/pulse/library/parametric_pulses.py
+++ b/qiskit/pulse/library/parametric_pulses.py
@@ -129,18 +129,13 @@ class ParametricPulse(Pulse):
         # midpoint sampling
         times = np.arange(0, self.duration) + 1/2
         if optionals.HAS_SYMENGINE:
+            # this should be simplified to handle piecewise function
             lambda_func = sym.lambdify(t, [assigned_expr.simplify()])
         else:
-            # lambda_func = sym.lambdify(t, assigned_expr.simplify())
             lambda_func = sym.lambdify(t, assigned_expr)
 
         waveform = lambda_func(times)
-        if not isinstance(waveform, np.ndarray):
-            # Workaround for constants being simplified to scalars
-            # See: https://github.com/sympy/sympy/issues/5642
-            waveform = waveform * np.ones(times.shape)
 
-        # this should be simplified to handle piecewise function
 
         return Waveform(samples=waveform, name=self.name)
 

--- a/qiskit/pulse/library/parametric_pulses.py
+++ b/qiskit/pulse/library/parametric_pulses.py
@@ -131,12 +131,16 @@ class ParametricPulse(Pulse):
         if optionals.HAS_SYMENGINE:
             lambda_func = sym.lambdify(t, [assigned_expr.simplify()])
         else:
-            lambda_func = sym.lambdify(t, assigned_expr.simplify())
+            # lambda_func = sym.lambdify(t, assigned_expr.simplify())
+            lambda_func = sym.lambdify(t, assigned_expr)
+
+        waveform = lambda_func(times)
+        if not isinstance(waveform, np.ndarray):
+            # Workaround for constants being simplified to scalars
+            # See: https://github.com/sympy/sympy/issues/5642
+            waveform = waveform * np.ones(times.shape)
 
         # this should be simplified to handle piecewise function
-        # waveform = np.vectorize(lambda ti: assigned_expr.subs(t, ti).simplify())(times)
-        # waveform = list(map(lambda ti: complex(assigned_expr.subs(t, ti).simplify()), times))
-        waveform = [lambda_func(ti) for ti in times]
 
         return Waveform(samples=waveform, name=self.name)
 

--- a/qiskit/pulse/library/symbolic.py
+++ b/qiskit/pulse/library/symbolic.py
@@ -59,6 +59,13 @@ def symbolic_drag():
 
 
 def symbolic_constant():
-    amp = sym.Symbol("amp")
+    t, duration, amp = sym.symbols("t, duration, amp")
 
-    return amp
+    # Note this is implemented using Piecewise instead of just returning amp
+    # directly because otherwise the expression has no t dependence and sympy's
+    # lambdify will produce a function f that for an array t returns amp
+    # instead of amp * np.ones(t.shape). This does not work well with
+    # ParametricPulse.get_waveform().
+    #
+    # See: https://github.com/sympy/sympy/issues/5642
+    return amp * sym.Piecewise((1, 0<= t <= duration), (0, True))


### PR DESCRIPTION
I played around with some different things on the `upgrade/serializable-parametric-pulse` branch. I thought a PR might be a good format for discussing what I saw. Here are some findings:

1. For sympy, the really slow step was trying to simplify the symbolic expression. Since we just end up evaluating the function any way, simplification seems unnecessary if it ends up taking more time than it might save with a simpler expression. Removing `simplify()` reduced the time needed to draw the schedule for the whole circuit in the performance check notebook from too long for me to wait (I think you said 10 minutes) to 2.7 seconds.
2. I got further savings for sympy by switching from the list comprehension to direct evaluation of the numpy array. That dropped the time to draw the circuit's schedule from 2.7 seconds to 0.6 seconds.
3. I encountered one issue with the constant function function after making these changes. sympy simplifies the expression to the point that it is scalar, so the lambda just returns a scalar instead of an array. I handled this case with special code that checks for an array. It worked for the notebook but maybe there is a better way.
4. Did you test the symengine case much? For me, it can't handle the full circuit schedule or the drag pulse. From further testing, I concluded that symengine does not support complex numbers in `lambdify`. This might be something to look into further (ask the `symengine` developers?). I also find it odd that the signature of `lambdify` is different for `sympy` and `symengine` (expression vs. iterable of expressions).
5. `symengine` did not have the issue of `lambdify` returning a function that returns a scalar when there is no `t` dependence.
6. For `Gaussian` and `GaussianSquare`, `symengine` was more than 10 time slower than `sympy` for the notebook cell tests.
7. `symengine` is probably slower becuase I left in the `simplify()` calls for it. I found that if I did not use `simplify()` that I got `RuntimeError: Not Implemented` for `Gaussian`, `GaussianSquare`, and `Constant`. This is the same error that I see for `Drag` (it's from a Cython file, so a bit tricky to debug). Perhaps there is something complex in the expressions that gets simplified to real or maybe it is something else.

I have not looked into qiskit's stance on sympy and symengine. Is it necessary to support both independently? Is casting symengine to sympy an option? I think symengine has a function for this but I don't know if qiskit needs to support having either one installed without the other. I think the symengine developers are pretty responsive if we have specific issues (but I don't know how much work these issues could require).